### PR TITLE
Fix when custom user data value is null

### DIFF
--- a/src/core/user.js
+++ b/src/core/user.js
@@ -84,7 +84,7 @@ class UserData {
   deserializerDataTypes() {
     for (var x in this.data) {
       // if we have an object, let's check for custom data types
-      if (typeof this.data[x] === 'object') {
+      if (this.data[x] && typeof this.data[x] === 'object') {
         // do we have a custom type?
         if (this.data[x].__Ionic_DataTypeSchema) {
           var name = this.data[x].__Ionic_DataTypeSchema;


### PR DESCRIPTION
It all started with a successful login that didn't resolved or rejected the promise.

The underlying problem was this:
`Cannot read property '__Ionic_DataTypeSchema' of null`

If you use custom data with Ionic.User and that data is saved the `deserializerDataTypes` process throws an exception that it's not captured as a promise reject.

Example:
```javascript
var user = Ionic.User.current();
user.set('something', null);
user.save();
```

So the next time you ask for the user like in the next login the process call the User.self() method that runs the `deserializerDataTypes` process.

This PR tries to solve that in a simple, yet effective way, just adding a validation that the value exists because today it uses the  `typeof value === 'object'` but `typeof null === 'object'` and when tries to call `this.data[x].__Ionic_DataTypeSchema` it fail.