### PR TITLE
Fixes #31

### DIFF
--- a/src/analytics/serializers.js
+++ b/src/analytics/serializers.js
@@ -13,7 +13,7 @@ export class DOMSerializer {
 
       var className = element.className;
       if (className) {
-        var classes = className.split(' ');
+        var classes = ('' + className).split(' ');
         for (var i = 0; i < classes.length; i++) {
           var c = classes[i];
           if (c) {


### PR DESCRIPTION
Related issue in deprecated ionic-service-analytics project can be found at https://github.com/driftyco/ionic-service-analytics/issues/34 .
More concretely, according to https://github.com/driftyco/ionic-service-analytics/issues/34#issuecomment-160252242 , the problem is that `className` becomes mistranslated into a `SVGAnimatedString` instead of a regular `string`.